### PR TITLE
Custom scale when fetching

### DIFF
--- a/cloudrun_functions/README.md
+++ b/cloudrun_functions/README.md
@@ -30,7 +30,7 @@ The supported endpoints are:
 
 ```json
 {
-	"source": "gs precomputed path like blah/jpeg",
+	"location": "bucket-name/path/to/emdata/raw/jpeg",
 	"start": [0,100,0],
 	"size": [256,256,256]
 }

--- a/cloudrun_functions/cloudbuild.yaml
+++ b/cloudrun_functions/cloudbuild.yaml
@@ -1,0 +1,15 @@
+steps:
+ - name: 'gcr.io/cloud-builders/docker'
+   entrypoint: 'bash'
+   args:
+   - '-c'
+   - |
+     docker pull gcr.io/PROJECT_ID/transferem:latest || exit 0
+ - name: 'gcr.io/cloud-builders/docker'
+   args: [
+            'build',
+            '-t', 'gcr.io/PROJECT_ID/transferem:latest',
+            '--cache-from', 'gcr.io/PROJECT_ID/transferem:latest',
+            '.'
+          ]
+images: ['gcr.io/PROJECT_ID/transferem:latest']

--- a/cloudrun_functions/transferem.py
+++ b/cloudrun_functions/transferem.py
@@ -21,16 +21,40 @@ logger = logging.getLogger(__name__)
 
 @app.route('/volume', methods=["POST"])
 def volume():
-    """Retrieve volume from tensorstore.
+    """
+    Retrieve volume from tensorstore.
+
+    Example usage:
+
+    corner_xyz = [0, 10, 20]
+    shape_xyz = [100, 200, 300]
+
+    config = {
+        'location': f'{mybucket}/neuroglancer/jpeg',
+        'start': corner_xyz,
+        'size': shape_xyz,
+        'scale_index': 4  # Optional, selects scale
+    }
+
+    r = requests.post(f'https://{service_base_url}/volume', json=config)
+    r.raise_for_status()
+
+    X, Y, Z = shape_xyz
+
+    # C-order, ZYX index
+    block_zyx = np.frombuffer(r.content, dtype=np.uint8).reshape((Z, Y, X))
+
+    # F-order, XYZ index
+    block_xyz = block_zyx.transpose()
     """
     try:
         config_file  = request.get_json()
-        
+
         location = config_file["location"] # contains source and destination
-        start = config_file["start"] # contains source and destination
-        size = config_file["size"] # contains source and destination
+        start = config_file["start"] # in XYZ order
+        size = config_file["size"] # in XYZ order
         scale_index = config_file.get("scale_index", 0)
-        
+
         location_arr = location.split('/')
         bucket = location_arr[0]
         path = '/'.join(location_arr[1:])
@@ -49,8 +73,38 @@ def volume():
         }).result()
         dataset = dataset[ts.d['channel'][0]]
 
-        data = dataset[start[0]:(start[0]+size[0]), start[1]:(start[1]+size[1]), start[2]:(start[2]+size[2])].read().result()
-        r = make_response(data.tobytes())
+        #      +--------------------------------------------------------------------+
+        #      | A quick guide to 3D array index semantics and memory order choices |
+        #      +--------------------------------------------------------------------+
+        #
+        # +-----------------+--------------+-----------------------------------------------+
+        # | Index semantics | Memory order | Notes                                         |
+        # +-----------------+--------------+-----------------------------------------------+
+        # |        a[Z,Y,X] | C            | Standard for Python users. Prefer this.       |
+        # |                 |              |                                               |
+        # |        a[X,Y,Z] | F            | Identical memory layout to the above,         |
+        # |                 |              | (the RAM contents are identical to the above) |
+        # |                 |              | but due to the reverse index meaning, this    |
+        # |                 |              | is likely to introduce confusion and/or       |
+        # |                 |              | accidental inefficiences when you pass this   |
+        # |                 |              | array to library functions which expect a     |
+        # |                 |              | standard C-order array.                       |
+        # |                 |              |                                               |
+        # |        a[Z,Y,X] | F            | Never do this.                                |
+        # |                 |              |                                               |
+        # |        a[X,Y,Z] | C            | Never do this.                                |
+        # +-----------------+--------------+-----------------------------------------------+
+
+        # Unfortunately, TensorStore.read() always returns an [X,Y,Z]-indexed array,
+        # but it does permit you to specify the memory ordering.
+        # Therefore, we request F-order, the only sane choice.
+        # The buffer we'll return to the caller can be interpreted as either F/XYZ or C/ZYX.
+        # (That's their business.)
+
+        x, y, z = start
+        sx, sy, sz = size
+        data = dataset[x:x+sx, y:y+sy, z:z+sz].read(order='F').result()
+        r = make_response(data.tobytes(order='F'))
         r.headers.set('Content-Type', 'application/octet-stream')
         return r
     except Exception as e:

--- a/cloudrun_functions/transferem.py
+++ b/cloudrun_functions/transferem.py
@@ -29,6 +29,7 @@ def volume():
         location = config_file["location"] # contains source and destination
         start = config_file["start"] # contains source and destination
         size = config_file["size"] # contains source and destination
+        scale_index = config_file.get("scale_index", 0)
         
         location_arr = location.split('/')
         bucket = location_arr[0]
@@ -44,7 +45,7 @@ def volume():
                 },
             'path': path,
             'recheck_cached_data': 'open',
-            'scale_index': 0 
+            'scale_index': scale_index
         }).result()
         dataset = dataset[ts.d['channel'][0]]
 

--- a/cloudrun_functions/transferem.py
+++ b/cloudrun_functions/transferem.py
@@ -28,7 +28,11 @@ def volume():
     try:
         config_file  = request.get_json()
 
+        # Strip gs:// prefix
         location = config_file["location"] # contains source and destination
+        if location.startswith('gs://'):
+            location = location[len('gs://'):]
+
         start = config_file["start"] # in XYZ order
         size = config_file["size"] # in XYZ order
         scale_index = config_file.get("scale_index", 0)
@@ -122,9 +126,6 @@ def fetch_subvolume(service_url, location, box_zyx, scale_index=0, dtype=None):
 
     if not service_url.startswith('https'):
         service_url = f'https://{service_url}'
-
-    if location.startswith('gs://'):
-        location = location[len('gs://'):]
 
     dtype = dtype or np.uint8
 


### PR DESCRIPTION
In the `/volume` endpoint, permit the user to specify which scale they're interested in.  Also, fix the memory order of the returned arrays.  Forgive the superfluous comments, I plan to copy them into a different project later.